### PR TITLE
Add missing bash declaration for non-bash shells

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 NAMESPACE=${DSTF_NAMESPACE:='desiredstate'}
 IMAGE=${DSTF_IMAGE:='dstf'}
 TAG=${DSTF_VERSION:='latest'}


### PR DESCRIPTION
Fix for non-bash shells